### PR TITLE
Fix all s/Tuesday/Wednesday/; update eventbrite/slack links

### DIFF
--- a/about.html
+++ b/about.html
@@ -17,7 +17,7 @@ description: Progressive Hack Night is a free event in New York to build an inte
     <h3 id='what-happens'>What’s a HackNight?</h3>
 
     <p>
-      Progressive Hack Night in NYC starts every other Tuesdayat 6:30 pm. We usually meet at ThoughtWorks, on the 15th floor of 99 Madison Ave in NYC. The event is free and the invitation is open to anyone--especially folks who aren’t programmers.<br/><br/>
+      Progressive Hack Night in NYC starts every other Wednesday at 6:30 pm. We usually meet at ThoughtWorks, on the 15th floor of 99 Madison Ave in NYC. The event is free and the invitation is open to anyone--especially folks who aren’t programmers.<br/><br/>
       We dedicate half of our events to speaker nights, where we learn to see and understand the experiences of those on the frontlines. The other half of our events focus on building technologies that support the work of grassroots organizers.
     </p>
 
@@ -46,7 +46,7 @@ description: Progressive Hack Night is a free event in New York to build an inte
     <!--<div class="row">-->
         <!--<div class="col-sm-12">-->
 
-            <p>Once a month, we have a presentation that lasts about an hour, followed by an open question & answer (Q&A) session.</p>
+            <p>Once a month, we have a presentation that lasts about an hour, followed by an open question &amp; answer (Q&amp;A) session.</p>
 
             <p>
               Presenters can be individuals, government agencies, non-profits, or groups who are creating a positive impact and want to engage with our community on progressive issues.

--- a/breakouts.html
+++ b/breakouts.html
@@ -35,7 +35,7 @@ description: Every HackNight, we break out into topic-specific working and learn
   </optgroup>
 </select>
 <p>Our breakout groups focus on mobilizing tech workers to discuss, strategize and create technology that dismantles structures of injustice and inequality. Our projects are developed in service to organizations without institutional monetary support. . Groups can last for one night or several years - it's up to you!</p>
-<p>If you are interested in getting involved in a breakout group, contact the project leader from their Github issue below, <a href="http://bit.ly/joinHackNight">join our Slack</a> to connect with them directly, or keep an eye out for them at one of our future HackNights.</p>
+<p>If you are interested in getting involved in a breakout group, contact the project leader from their Github issue below, <a href="http://bit.ly/joinProgHackNight">join our Slack</a> to connect with them directly, or keep an eye out for them at one of our future HackNights.</p>
 
 <table id='working-groups' class='table table-bordered'>
   <tbody>

--- a/community.html
+++ b/community.html
@@ -1,12 +1,12 @@
 ---
 layout: default
 title: Community
-description: Progressive Hacknight is a central hub for Chicago's civic tech community. The easiest thing you can do get involved is show up to a Tuesday Progressive Hacknight. In addition to that, there are many ways to get involved.
+description: Progressive Hacknight is a central hub for Chicago's civic tech community. The easiest thing you can do get involved is show up to a Wednesday Progressive Hacknight. In addition to that, there are many ways to get involved.
 ---
 
 <h1>Community</h1>
 
-<p>Progressive Hacknight is a central hub for Chicago's civic tech community. The easiest thing you can do get involved is <strong>show up to a Tuesday Progressive Hacknight</strong>. In addition to that, there are many ways to get involved:</p>
+<p>Progressive Hacknight is a central hub for Chicago's civic tech community. The easiest thing you can do get involved is <strong>show up to a Wednesday Progressive Hacknight</strong>. In addition to that, there are many ways to get involved:</p>
 
 <div class='row'>
   <div class='col-sm-4'>

--- a/community.html
+++ b/community.html
@@ -21,7 +21,7 @@ description: Progressive Hacknight is a central hub for Chicago's civic tech com
   <div class='col-sm-4'>
     <div class='well'>
       <p>Join our Slack Team to keep up with news and projects in New York.</p>
-      <a class='btn btn-success' href='https://join.slack.com/progressivehacknight/shared_invite/MTk4NTQ2NjM1MTI1LTE0OTc1NDc5MTctNWYzOTI2MDg1NQ'>
+      <a class='btn btn-success' href='https://bit.ly/joinProgHackNight'>
         <i class='fa fa-envelope'></i>
         Join our Slack Team
       </a>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@ layout: default
 
     <h2 id='about'>About Progressive HackNight</h2>
 
-    <p>Join us every other Tuesday from 6:30 to 9:30 pm on the 15th floor of ThoughtWorks NYC to hear from <a href='/events/index.html'>amazing speakers</a>, discuss progressive issues and <a href='/breakouts.html'>work on grassroots projects</a>. <a href='/about.html#everyone'><strong>Everyone is welcome!</strong></a></p>
+    <p>Join us every other Wednesday from 6:30 to 9:30 pm on the 15th floor of ThoughtWorks NYC to hear from <a href='/events/index.html'>amazing speakers</a>, discuss progressive issues and <a href='/breakouts.html'>work on grassroots projects</a>. <a href='/about.html#everyone'><strong>Everyone is welcome!</strong></a></p>
     <p>Progressive HackNight creates a space for tech workers to build technology and relationships.</p>
     <p>At each HackNight, learning groups meet to discuss and strategize about important issues, and working groups provide opportunities for our members to use their skills to create a positive impact. Through our learning groups and working groups, we create networks inside and outside our organizations.</p>
 
@@ -37,7 +37,7 @@ layout: default
       <div class='col-sm-4'>
         <div class='well'>
           <h1><i class='fa fa-fw fa-calendar'></i></h1>
-          <p>1. Come to Progressive Hacknight! <a href='https://www.eventbrite.com/e/progressive-hacknight-at-thoughtworks-tickets-39424865835'>We meet every other Tuesday at 6:30pm</a></p>
+          <p>1. Come to Progressive Hacknight! <a href='https://www.eventbrite.com/o/progressive-hacknight-26355863585'>We meet every other Wednesday at 6:30pm</a></p>
         </div>
       </div>
 


### PR DESCRIPTION
Make the front page eventbrite link go to the new eventbrite org which will have all the events. (It previously went to an old event on the old org.) There are some other eventbrite links I didn't update on the event template (though this doesn't seem very used anymore). Some minor other typos.